### PR TITLE
Added a default path for venv

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "python-envs.defaultEnvManager": "ms-python.python:pipenv",
-    "python-envs.pythonProjects": []
+    "python-envs.pythonProjects": [],
+    "python.defaultInterpreterPath": "${workspaceFolder}/server"
 }


### PR DESCRIPTION
I was having issues with the venv so I added a default path in /server since that is where our pipfiles are located. This means each one of us can only activate their venv while inside /server and not on the root folder thus the venv will always be (server).